### PR TITLE
Add ALPN/NextProtos helpers for TLS config

### DIFF
--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -41,6 +41,15 @@ var (
 	DefaultTLSCiphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers //nolint:gochecknoglobals
 	// DefaultMinTLSVersion is the default minimum TLS version for API servers.
 	DefaultMinTLSVersion = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion //nolint:gochecknoglobals
+
+	// HTTP2NextProtos are the ALPN protocols advertised when HTTP/2 is enabled,
+	// with HTTP/1.1 fallback.
+	HTTP2NextProtos = []string{"h2", "http/1.1"} //nolint:gochecknoglobals
+
+	// HTTP1NextProtos are the ALPN protocols advertised when HTTP/2 is disabled.
+	// Use this as a mitigation for HTTP/2 Rapid Reset vulnerabilities
+	// (CVE-2023-44487, CVE-2023-39325).
+	HTTP1NextProtos = []string{"http/1.1"} //nolint:gochecknoglobals
 )
 
 // FetchAPIServerTLSProfile fetches the TLS profile spec configured in APIServer.
@@ -129,6 +138,43 @@ func NewTLSConfigFromProfile(profile configv1.TLSProfileSpec) (tlsConfig func(*t
 			tlsConf.CipherSuites = cipherSuites
 		}
 	}, unsupportedCiphers
+}
+
+// SetNextProtos returns a TLS configuration function that sets the ALPN
+// protocol negotiation list on a tls.Config.
+// The returned function is intended to be used with controller-runtime's TLSOpts.
+//
+// Example:
+//
+//	tlsOpts := []func(*tls.Config){
+//	    openshifttls.SetNextProtos("h2", "http/1.1"),
+//	}
+func SetNextProtos(protos ...string) func(*tls.Config) {
+	p := make([]string, len(protos))
+	copy(p, protos)
+	return func(c *tls.Config) {
+		c.NextProtos = p
+	}
+}
+
+// WithHTTP2 returns a TLS configuration function that configures ALPN
+// protocol negotiation based on whether HTTP/2 should be enabled.
+//
+// When enabled is true, both "h2" and "http/1.1" are advertised.
+// When enabled is false, only "http/1.1" is advertised as a mitigation
+// for HTTP/2 Rapid Reset vulnerabilities (CVE-2023-44487, CVE-2023-39325).
+//
+// The returned function is intended to be used with controller-runtime's TLSOpts.
+//
+// Example:
+//
+//	tlsConfig, _ := openshifttls.NewTLSConfigFromProfile(profile)
+//	tlsOpts := []func(*tls.Config){tlsConfig, openshifttls.WithHTTP2(false)}
+func WithHTTP2(enabled bool) func(*tls.Config) {
+	if enabled {
+		return SetNextProtos(HTTP2NextProtos...)
+	}
+	return SetNextProtos(HTTP1NextProtos...)
 }
 
 // cipherCode returns the TLS cipher code for an OpenSSL or IANA cipher name.

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -142,43 +142,31 @@ func NewTLSConfigFromProfile(profile configv1.TLSProfileSpec) (tlsConfig func(*t
 }
 
 // SetNextProtos returns a TLS configuration function that sets the ALPN
-// protocol negotiation list on a tls.Config.
+// protocol negotiation list on a tls.Config. Empty strings are silently
+// ignored, which allows conditional protocol inclusion.
 // The returned function is intended to be used with controller-runtime's TLSOpts.
 //
 // Example:
 //
-//	tlsOpts := []func(*tls.Config){
-//	    openshifttls.SetNextProtos("h2", "http/1.1"),
-//	}
+//	// Disable HTTP/2:
+//	openshifttls.SetNextProtos("http/1.1")
+//
+//	// Enable HTTP/2 with fallback:
+//	openshifttls.SetNextProtos("h2", "http/1.1")
+//
+//	// Using the well-known protocol lists:
+//	openshifttls.SetNextProtos(openshifttls.HTTP1NextProtos...)
+//	openshifttls.SetNextProtos(openshifttls.HTTP2NextProtos...)
 func SetNextProtos(protos ...string) func(*tls.Config) {
 	var p []string
-	if len(protos) > 0 {
-		p = make([]string, len(protos))
-		copy(p, protos)
+	for _, proto := range protos {
+		if proto != "" {
+			p = append(p, proto)
+		}
 	}
 	return func(c *tls.Config) {
 		c.NextProtos = p
 	}
-}
-
-// WithHTTP2 returns a TLS configuration function that configures ALPN
-// protocol negotiation based on whether HTTP/2 should be enabled.
-//
-// When enabled is true, both "h2" and "http/1.1" are advertised.
-// When enabled is false, only "http/1.1" is advertised as a mitigation
-// for HTTP/2 Rapid Reset vulnerabilities (CVE-2023-44487, CVE-2023-39325).
-//
-// The returned function is intended to be used with controller-runtime's TLSOpts.
-//
-// Example:
-//
-//	tlsConfig, _ := openshifttls.NewTLSConfigFromProfile(profile)
-//	tlsOpts := []func(*tls.Config){tlsConfig, openshifttls.WithHTTP2(false)}
-func WithHTTP2(enabled bool) func(*tls.Config) {
-	if enabled {
-		return SetNextProtos(HTTP2NextProtos...)
-	}
-	return SetNextProtos(HTTP1NextProtos...)
 }
 
 // cipherCode returns the TLS cipher code for an OpenSSL or IANA cipher name.

--- a/pkg/tls/tls.go
+++ b/pkg/tls/tls.go
@@ -46,9 +46,10 @@ var (
 	// with HTTP/1.1 fallback.
 	HTTP2NextProtos = []string{"h2", "http/1.1"} //nolint:gochecknoglobals
 
-	// HTTP1NextProtos are the ALPN protocols advertised when HTTP/2 is disabled.
-	// Use this as a mitigation for HTTP/2 Rapid Reset vulnerabilities
-	// (CVE-2023-44487, CVE-2023-39325).
+	// HTTP1NextProtos are the ALPN protocols advertised when HTTP/2 is disabled,
+	// restricting negotiation to HTTP/1.1 only. This provides defense-in-depth
+	// against HTTP/2 Rapid Reset (CVE-2023-44487, CVE-2023-39325) alongside
+	// the primary fixes in Go 1.21.3+ and golang.org/x/net v0.17.0+.
 	HTTP1NextProtos = []string{"http/1.1"} //nolint:gochecknoglobals
 )
 
@@ -150,8 +151,11 @@ func NewTLSConfigFromProfile(profile configv1.TLSProfileSpec) (tlsConfig func(*t
 //	    openshifttls.SetNextProtos("h2", "http/1.1"),
 //	}
 func SetNextProtos(protos ...string) func(*tls.Config) {
-	p := make([]string, len(protos))
-	copy(p, protos)
+	var p []string
+	if len(protos) > 0 {
+		p = make([]string, len(protos))
+		copy(p, protos)
+	}
 	return func(c *tls.Config) {
 		c.NextProtos = p
 	}

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -205,11 +205,11 @@ var _ = Describe("SetNextProtos", func() {
 		Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
 	})
 
-	It("should handle no protocols", func() {
+	It("should handle no protocols by preserving nil semantics", func() {
 		fn := SetNextProtos()
 		c := &tls.Config{}
 		fn(c)
-		Expect(c.NextProtos).To(BeEmpty())
+		Expect(c.NextProtos).To(BeNil())
 	})
 
 	It("should not be affected by modification of the original slice", func() {

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -212,6 +212,20 @@ var _ = Describe("SetNextProtos", func() {
 		Expect(c.NextProtos).To(BeNil())
 	})
 
+	It("should ignore empty strings", func() {
+		fn := SetNextProtos("", "http/1.1")
+		c := &tls.Config{}
+		fn(c)
+		Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
+	})
+
+	It("should return nil when all protocols are empty strings", func() {
+		fn := SetNextProtos("", "")
+		c := &tls.Config{}
+		fn(c)
+		Expect(c.NextProtos).To(BeNil())
+	})
+
 	It("should not be affected by modification of the original slice", func() {
 		protos := []string{"h2", "http/1.1"}
 		fn := SetNextProtos(protos...)
@@ -227,26 +241,6 @@ var _ = Describe("SetNextProtos", func() {
 		fn(c)
 		Expect(c.NextProtos).To(Equal([]string{"h2", "http/1.1"}))
 	})
-})
-
-var _ = Describe("WithHTTP2", func() {
-	Context("when HTTP/2 is enabled", func() {
-		It("should set NextProtos to h2 and http/1.1", func() {
-			fn := WithHTTP2(true)
-			c := &tls.Config{}
-			fn(c)
-			Expect(c.NextProtos).To(Equal([]string{"h2", "http/1.1"}))
-		})
-	})
-
-	Context("when HTTP/2 is disabled", func() {
-		It("should set NextProtos to http/1.1 only", func() {
-			fn := WithHTTP2(false)
-			c := &tls.Config{}
-			fn(c)
-			Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
-		})
-	})
 
 	It("should compose with NewTLSConfigFromProfile", func() {
 		profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
@@ -254,10 +248,22 @@ var _ = Describe("WithHTTP2", func() {
 
 		c := &tls.Config{}
 		tlsConfigFn(c)
-		WithHTTP2(false)(c)
+		SetNextProtos("http/1.1")(c)
 
 		Expect(c.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
 		Expect(c.CipherSuites).NotTo(BeEmpty())
+		Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
+	})
+
+	It("should work with the well-known protocol lists", func() {
+		fn := SetNextProtos(HTTP2NextProtos...)
+		c := &tls.Config{}
+		fn(c)
+		Expect(c.NextProtos).To(Equal([]string{"h2", "http/1.1"}))
+
+		fn = SetNextProtos(HTTP1NextProtos...)
+		c = &tls.Config{}
+		fn(c)
 		Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
 	})
 })

--- a/pkg/tls/tls_test.go
+++ b/pkg/tls/tls_test.go
@@ -190,6 +190,88 @@ var _ = Describe("cipherCodes", func() {
 	})
 })
 
+var _ = Describe("SetNextProtos", func() {
+	It("should set NextProtos on tls.Config", func() {
+		fn := SetNextProtos("h2", "http/1.1")
+		c := &tls.Config{}
+		fn(c)
+		Expect(c.NextProtos).To(Equal([]string{"h2", "http/1.1"}))
+	})
+
+	It("should handle a single protocol", func() {
+		fn := SetNextProtos("http/1.1")
+		c := &tls.Config{}
+		fn(c)
+		Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
+	})
+
+	It("should handle no protocols", func() {
+		fn := SetNextProtos()
+		c := &tls.Config{}
+		fn(c)
+		Expect(c.NextProtos).To(BeEmpty())
+	})
+
+	It("should not be affected by modification of the original slice", func() {
+		protos := []string{"h2", "http/1.1"}
+		fn := SetNextProtos(protos...)
+		protos[0] = "modified"
+		c := &tls.Config{}
+		fn(c)
+		Expect(c.NextProtos).To(Equal([]string{"h2", "http/1.1"}))
+	})
+
+	It("should override any existing NextProtos", func() {
+		fn := SetNextProtos("h2", "http/1.1")
+		c := &tls.Config{NextProtos: []string{"old-proto"}}
+		fn(c)
+		Expect(c.NextProtos).To(Equal([]string{"h2", "http/1.1"}))
+	})
+})
+
+var _ = Describe("WithHTTP2", func() {
+	Context("when HTTP/2 is enabled", func() {
+		It("should set NextProtos to h2 and http/1.1", func() {
+			fn := WithHTTP2(true)
+			c := &tls.Config{}
+			fn(c)
+			Expect(c.NextProtos).To(Equal([]string{"h2", "http/1.1"}))
+		})
+	})
+
+	Context("when HTTP/2 is disabled", func() {
+		It("should set NextProtos to http/1.1 only", func() {
+			fn := WithHTTP2(false)
+			c := &tls.Config{}
+			fn(c)
+			Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
+		})
+	})
+
+	It("should compose with NewTLSConfigFromProfile", func() {
+		profile := *configv1.TLSProfiles[configv1.TLSProfileIntermediateType]
+		tlsConfigFn, _ := NewTLSConfigFromProfile(profile)
+
+		c := &tls.Config{}
+		tlsConfigFn(c)
+		WithHTTP2(false)(c)
+
+		Expect(c.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+		Expect(c.CipherSuites).NotTo(BeEmpty())
+		Expect(c.NextProtos).To(Equal([]string{"http/1.1"}))
+	})
+})
+
+var _ = Describe("ALPN protocol variables", func() {
+	It("HTTP2NextProtos should contain h2 and http/1.1", func() {
+		Expect(HTTP2NextProtos).To(Equal([]string{"h2", "http/1.1"}))
+	})
+
+	It("HTTP1NextProtos should contain only http/1.1", func() {
+		Expect(HTTP1NextProtos).To(Equal([]string{"http/1.1"}))
+	})
+})
+
 var _ = Describe("NewTLSConfigFromProfile", func() {
 	Context("when MinTLSVersion is TLS 1.2", func() {
 		It("should set MinVersion and CipherSuites", func() {


### PR DESCRIPTION
## Summary

Adds composable ALPN protocol negotiation helpers to `pkg/tls`, eliminating
copy-paste boilerplate found in 49+ repos across the openshift org.

Currently every operator using `NewTLSConfigFromProfile` must manually append
a `func(*tls.Config)` to set `tls.Config.NextProtos`. This change provides:

- `HTTP2NextProtos` / `HTTP1NextProtos`: well-known ALPN protocol lists
- `SetNextProtos(protos ...string)`: explicit ALPN setter with defensive copy and empty-string filtering

**Before** (every operator today):
```go
// Fetch the cluster TLS profile
tlsProfile, err := openshifttls.FetchAPIServerTLSProfile(ctx, client)
if err != nil {
    return fmt.Errorf("failed to get tls profile: %w", err)
}

// Build TLS config from the profile
tlsConfig, unsupported := openshifttls.NewTLSConfigFromProfile(tlsProfile)
if len(unsupported) > 0 {
    setupLog.Info("unsupported ciphers", "ciphers", unsupported)
}

// Manually set ALPN (copy-pasted across 49+ repos)
disableHTTP2 := func(c *tls.Config) {
    setupLog.Info("disabling http/2")
    c.NextProtos = []string{"http/1.1"}
}

// Wire into controller-runtime
mgr, err := ctrl.NewManager(cfg, ctrl.Options{
    Metrics: metricsserver.Options{
        TLSOpts: []func(*tls.Config){tlsConfig, disableHTTP2},
    },
    WebhookServer: &webhook.DefaultServer{Options: webhook.Options{
        TLSOpts: []func(*tls.Config){tlsConfig, disableHTTP2},
    }},
})
```

**After:**
```go
// Fetch the cluster TLS profile
tlsProfile, err := openshifttls.FetchAPIServerTLSProfile(ctx, client)
if err != nil {
    return fmt.Errorf("failed to get tls profile: %w", err)
}

// Build TLS config from the profile
tlsConfig, unsupported := openshifttls.NewTLSConfigFromProfile(tlsProfile)
if len(unsupported) > 0 {
    setupLog.Info("unsupported ciphers", "ciphers", unsupported)
}

// Compose profile + ALPN into a single TLSOpts slice
tlsOpts := []func(*tls.Config){tlsConfig, openshifttls.SetNextProtos(openshifttls.HTTP1NextProtos...)}

// Wire into controller-runtime
mgr, err := ctrl.NewManager(cfg, ctrl.Options{
    Metrics: metricsserver.Options{
        TLSOpts: tlsOpts,
    },
    WebhookServer: &webhook.DefaultServer{Options: webhook.Options{
        TLSOpts: tlsOpts,
    }},
})
```

Other usage patterns:
```go
// Disable HTTP/2 (defense-in-depth for CVE-2023-44487)
openshifttls.SetNextProtos(openshifttls.HTTP1NextProtos...)

// Enable HTTP/2 with HTTP/1.1 fallback
openshifttls.SetNextProtos(openshifttls.HTTP2NextProtos...)

// Inline protocol values
openshifttls.SetNextProtos("h2", "http/1.1")

// Conditional inclusion (empty strings are filtered out)
openshifttls.SetNextProtos(conditionalH2, "http/1.1")

// Use the exported vars directly when building a tls.Config outside TLSOpts
cfg := &tls.Config{
    NextProtos: openshifttls.HTTP1NextProtos,
}
```

## Concrete use-cases

Repos already using `NewTLSConfigFromProfile` alongside manual NextProtos:

- openshift/lvm-operator (`cmd/operator/operator.go`, `cmd/vgmanager/vgmanager.go`)
- openshift/ptp-operator (`main.go`)
- openshift/pf-status-relay-operator (`cmd/main.go`)
- openshift/vertical-pod-autoscaler-operator (`cmd/main.go`)
- openshift/cluster-node-tuning-operator (`cmd/cluster-node-tuning-operator/main.go`)

GitHub code search shows 49 total repos in the openshift org with this pattern.

## Design decisions

- **Separate from `NewTLSConfigFromProfile`**: NextProtos is HTTP protocol
  negotiation, not TLS cipher/version selection. Different consumers want
  different values. Composable functions preserve the existing API.
- **Explicit over opinionated**: callers directly control the protocol list
  they're setting rather than going through a boolean abstraction.
- **Defensive copy in `SetNextProtos`**: prevents callers from mutating the
  captured slice.
- **Empty-string filtering**: allows conditional protocol inclusion without
  requiring wrapper functions.
- **nil preservation**: `SetNextProtos()` with zero non-empty args returns nil
  to preserve `tls.Config` default semantics.
- **Follows existing patterns**: `func(*tls.Config)` return type, exported
  package-level vars with `nolint:gochecknoglobals`, Ginkgo/Gomega tests.

## Verification

- `make test` passes (all tests green with race detector)
- `make lint` passes (0 issues)